### PR TITLE
Implement crt0 for linux.

### DIFF
--- a/src/posix/stdlib.rs
+++ b/src/posix/stdlib.rs
@@ -103,10 +103,10 @@ pub extern fn exit(x: int_t) -> ! {
     _exit(x);
 }
 
+/// _Exit is a synonym for _exit
 #[no_mangle]
 pub extern fn _Exit(x: int_t) -> ! {
-    unsafe {sys_exit(x);}
-    loop { }; // for divergence check
+    _exit(x);
 }
 
 #[no_mangle]

--- a/src/rust/x86_64/linux/start.rs
+++ b/src/rust/x86_64/linux/start.rs
@@ -1,10 +1,31 @@
+use rust::prelude::*;
+use types::{int_t, char_t};
+use posix::stdlib::{ARGV, ARGC, ENVP, ENVC, exit};
+
+extern "C" {
+	fn main(argc: int_t,
+			argv: *const *const char_t,
+			envp: *const *const char_t) -> int_t;
+}
+
+/// This function is called _start to match the OS X target's name mangling.
+/// It stores the addresses of the stack arguments, invokes main(), and passes
+/// the return status to exit().
 #[no_mangle]
 pub unsafe extern fn _start() {
-    asm!("pop   %rdi
-    	mov   %rsp,%rsi
-    	push  %rdi
-    	call  main
-    	mov   %rax,%rdi
-    	mov   $$60,%rax
-    	syscall");
+    asm!("	mov (%rsp), $0
+    		lea +8(%rsp), $1"
+    		: "=r"(ARGC), "=r"(ARGV) ::: "volatile");
+
+    ENVP = offset(ARGV, ARGC as int + 1);
+
+    let mut envc: *const *const char_t = ENVP;
+    while (*envc as uint != 0) {
+        envc = offset(envc, 1); // increases by one pointer size
+    }
+    ENVC = (envc as uint - ENVP as uint - 1);
+
+    let status = main(ARGC as int_t, ARGV, ENVP);
+
+	exit(status);
 }

--- a/src/rust/x86_64/macos/start.rs
+++ b/src/rust/x86_64/macos/start.rs
@@ -1,7 +1,6 @@
-use types::{int_t, char_t, void_t};
-use posix::stdlib::{ARGV, ARGC, ENVP, ENVC, APPLE, exit};
-
 use rust::prelude::*;
+use types::{int_t, char_t};
+use posix::stdlib::{ARGV, ARGC, ENVP, ENVC, APPLE, exit};
 
 extern "C" {
 	fn main(argc: int_t,

--- a/test.c
+++ b/test.c
@@ -3,7 +3,7 @@
 int main(int argc, char const *argv[])
 {
 	puts("Hello, world!");
-	//puts(getenv("HOME"));
+	puts(getenv("HOME"));
 
 	memcmp("bbb", "aaa", 3);
 	return 0;


### PR DESCRIPTION
This addresses, and should be the correct fix for, the segmentation
fault that occurred in the linux test case when getenv was called.

Before merging or closing, could you confirm the Linux case runs?