### PR TITLE
Add utime() and mmap(), uint -> usize, bugfixes

### DIFF
--- a/include/rlibc/libc.h
+++ b/include/rlibc/libc.h
@@ -11,6 +11,8 @@ typedef signed int int32_t;
 typedef unsigned int uint32_t;
 typedef signed long int64_t;
 typedef unsigned long uint64_t;
+typedef int64_t intptr_t;
+typedef uint64_t uintptr_t;
 typedef uint64_t size_t;
 typedef int64_t ssize_t;
 typedef int64_t off_t;
@@ -71,6 +73,13 @@ int remove(const char *);
 int rename(const char *, const char *);
 int rmdir(const char*);
 int unlink(const char *);
+int utime(const char *, void *);
+
+/* Memory Management */
+void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+int munmap(void *addr, size_t length);
+int brk(void *);
+void *sbrk(intptr_t);
 
 /* Environment */
 extern int errno;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,10 @@
 #![crate_name="rlibc"]
 #![crate_type="staticlib"]
 #![allow(non_camel_case_types)]
-#![allow(visible_private_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
-#![feature(asm, globs, macro_rules, lang_items, intrinsics)]
+#![allow(unstable)]
+#![feature(asm, lang_items, intrinsics)]
 
 extern crate core;
 
@@ -17,6 +17,7 @@ pub use rust::x86_64::linux::start::__libc_start_main;
 		  all(target_os = "ios", target_arch = "x86_64")))]
 pub use rust::x86_64::macos::start::_libc_start_main;
 
+#[macro_use]
 mod rust;
 
 mod types;

--- a/src/libc/string.rs
+++ b/src/libc/string.rs
@@ -4,7 +4,7 @@ use types::{uchar_t, char_t, int_t, size_t};
 
 #[no_mangle]
 pub unsafe extern fn memcpy(dst: *mut char_t, src: *const char_t, n: size_t) -> *mut char_t {
-    for i in range(0, n as int).rev() {
+    for i in range(0, n as isize).rev() {
         *offset_mut(dst, i) = *offset(src, i);
     }
     dst
@@ -12,10 +12,10 @@ pub unsafe extern fn memcpy(dst: *mut char_t, src: *const char_t, n: size_t) -> 
 
 #[no_mangle]
 pub unsafe extern fn memmove(dst: *mut char_t, src: *const char_t, n: size_t) -> *mut char_t {
-    if (dst as uint) > (src as uint) {
+    if (dst as usize) > (src as usize) {
         return memcpy(dst, src, n);
     }
-    for i in range(0, n as int) {
+    for i in range(0, n as isize) {
         *offset_mut(dst, i) = *offset(src, i);
     }
     dst
@@ -34,7 +34,7 @@ pub unsafe extern fn strcpy(dst: *mut char_t, src: *const char_t) -> *mut char_t
 
 #[no_mangle]
 pub unsafe extern fn strncpy(dst: *mut char_t, src: *const char_t, n: size_t) -> *mut char_t {
-    let n = n as int;
+    let n = n as isize;
     let mut i = 0;
     while i < n && *offset(src, i) != 0 {
         *offset_mut(dst, i) = *offset(src, i);
@@ -49,7 +49,7 @@ pub unsafe extern fn strncpy(dst: *mut char_t, src: *const char_t, n: size_t) ->
 
 #[no_mangle]
 pub unsafe extern fn strcat(dst: *mut char_t, src: *const char_t) -> *mut char_t {
-    let base = strlen(dst as *const _) as int;
+    let base = strlen(dst as *const _) as isize;
     let mut i = 0;
     while *offset(src, i) != 0 {
         *offset_mut(dst, base+i) = *offset(src, i);
@@ -61,8 +61,8 @@ pub unsafe extern fn strcat(dst: *mut char_t, src: *const char_t) -> *mut char_t
 
 #[no_mangle]
 pub unsafe extern fn strncat(dst: *mut char_t, src: *const char_t, n: size_t) -> *mut char_t {
-    let base = strlen(dst as *const _) as int;
-    for i in range(0, n as int) {
+    let base = strlen(dst as *const _) as isize;
+    for i in range(0, n as isize) {
         *offset_mut(dst, base+i) = *offset(src, i);
         if *offset(src, i) == 0 {
             break;
@@ -75,9 +75,9 @@ pub unsafe extern fn strncat(dst: *mut char_t, src: *const char_t, n: size_t) ->
 pub unsafe extern fn memcmp(m1: *const char_t, m2: *const char_t, n: size_t) -> int_t {
     let m1 = m1 as *const uchar_t;
     let m2 = m2 as *const uchar_t;
-    for i in range(0, n as int) {
-        let v1 = *offset(m1, i) as int;
-        let v2 = *offset(m2, i) as int;
+    for i in range(0, n as isize) {
+        let v1 = *offset(m1, i) as isize;
+        let v2 = *offset(m2, i) as isize;
         match v1 - v2 {
             j if j < 0 => return -1,
             j if j > 0 => return 1,
@@ -91,9 +91,9 @@ pub unsafe extern fn memcmp(m1: *const char_t, m2: *const char_t, n: size_t) -> 
 pub unsafe extern fn strcmp(m1: *const char_t, m2: *const char_t) -> int_t {
     let m1 = m1 as *const uchar_t;
     let m2 = m2 as *const uchar_t;
-    for i in count(0i, 1) {
-        let v1 = *offset(m1, i) as int;
-        let v2 = *offset(m2, i) as int;
+    for i in count(0is, 1) {
+        let v1 = *offset(m1, i) as isize;
+        let v2 = *offset(m2, i) as isize;
         match v1 - v2 {
             j if j < 0 => return -1,
             j if j > 0 => return 1,
@@ -115,9 +115,9 @@ pub unsafe extern fn strcoll(m1: *const char_t, m2: *const char_t) -> int_t {
 pub unsafe extern fn strncmp(m1: *const char_t, m2: *const char_t, n: size_t) -> int_t {
     let m1 = m1 as *const uchar_t;
     let m2 = m2 as *const uchar_t;
-    for i in range(0, n as int) {
-        let v1 = *offset(m1, i) as int;
-        let v2 = *offset(m2, i) as int;
+    for i in range(0, n as isize) {
+        let v1 = *offset(m1, i) as isize;
+        let v2 = *offset(m2, i) as isize;
         match v1 - v2 {
             j if j < 0 => return -1,
             j if j > 0 => return 1,
@@ -142,7 +142,7 @@ pub unsafe extern fn strxfrm(dst: *mut char_t, src: *const char_t, n: size_t) ->
 #[no_mangle]
 pub unsafe extern fn memchr(s: *const char_t, c: int_t, n: size_t) -> *const char_t {
     let c = c as char_t;
-    for i in range(0, n as int) {
+    for i in range(0, n as isize) {
         if *offset(s, i) == c {
             return offset(s, i);
         }
@@ -153,7 +153,7 @@ pub unsafe extern fn memchr(s: *const char_t, c: int_t, n: size_t) -> *const cha
 #[no_mangle]
 pub unsafe extern fn strchr(s: *const char_t, c: int_t) -> *const char_t {
     if c == 0 {
-        return offset(s, strlen(s) as int);
+        return offset(s, strlen(s) as isize);
     }
     let c = c as char_t;
     let mut i = 0;
@@ -171,7 +171,7 @@ pub unsafe extern fn strcspn(s1: *const char_t, s2: *const char_t) -> size_t {
     let len = strlen(s2);
     let mut i = 0;
     while *offset(s1, i) != 0 {
-        if memchr(s2, *offset(s1, i) as int_t, len) as uint != 0 {
+        if memchr(s2, *offset(s1, i) as int_t, len) as usize != 0 {
             break;
         }
         i += 1;
@@ -184,7 +184,7 @@ pub unsafe extern fn strpbrk(s1: *const char_t, s2: *const char_t) -> *const cha
     let len = strlen(s2);
     let mut i = 0;
     while *offset(s1, i) != 0 {
-        if memchr(s2, *offset(s1, i) as int_t, len) as uint == 0 {
+        if memchr(s2, *offset(s1, i) as int_t, len) as usize == 0 {
             return offset(s1, i);
         }
         i += 1;
@@ -213,7 +213,7 @@ pub unsafe extern fn strspn(s1: *const char_t, s2: *const char_t) -> size_t {
     let len = strlen(s2);
     let mut i = 0;
     while *offset(s1, i) != 0 {
-        if memchr(s2, *offset(s1, i) as int_t, len) as uint == 0 {
+        if memchr(s2, *offset(s1, i) as int_t, len) as usize == 0 {
             break;
         }
         i += 1;
@@ -223,8 +223,8 @@ pub unsafe extern fn strspn(s1: *const char_t, s2: *const char_t) -> size_t {
 
 #[no_mangle]
 pub unsafe extern fn strstr(s1: *const char_t, s2: *const char_t) -> *const char_t {
-    let len1 = strlen(s1) as int;
-    let len2 = strlen(s2) as int;
+    let len1 = strlen(s1) as isize;
+    let len2 = strlen(s2) as isize;
     for i in range(0, len1 - len2) {
         if memcmp(offset(s1, i), s2, len2 as size_t) == 0 {
             return offset(s1, i);
@@ -236,18 +236,18 @@ pub unsafe extern fn strstr(s1: *const char_t, s2: *const char_t) -> *const char
 #[no_mangle]
 pub unsafe extern fn strtok(s1: *mut char_t, s2: *const char_t) -> *const char_t {
     static mut ss: *mut char_t = 0 as *mut char_t;
-    static mut len: int = 0;
-    if s1 as uint != 0 {
+    static mut len: isize = 0;
+    if s1 as usize != 0 {
         ss = s1;
-        len = strlen(ss as *const _) as int;
+        len = strlen(ss as *const _) as isize;
     }
-    if ss as uint == 0 {
+    if ss as usize == 0 {
         return 0 as *const char_t;
     }
-    let len2 = strlen(s2) as int;
+    let len2 = strlen(s2) as isize;
     let mut i = 0;
     while i < len {
-        if memchr(s2, *offset_mut(ss, i) as int_t, len2 as size_t) as uint != 0 {
+        if memchr(s2, *offset_mut(ss, i) as int_t, len2 as size_t) as usize != 0 {
             break;
         }
         i += 1;
@@ -260,7 +260,7 @@ pub unsafe extern fn strtok(s1: *mut char_t, s2: *const char_t) -> *const char_t
     }
     let mut i = 0;
     while i < len {
-        if memchr(s2, *offset_mut(ss, i) as int_t, len2 as size_t) as uint == 0 {
+        if memchr(s2, *offset_mut(ss, i) as int_t, len2 as size_t) as usize == 0 {
             break;
         }
         i += 1;
@@ -281,7 +281,7 @@ pub unsafe extern fn strtok(s1: *mut char_t, s2: *const char_t) -> *const char_t
 #[no_mangle]
 pub unsafe extern fn memset(dst: *mut char_t, c: int_t, n: size_t) -> *mut char_t {
     let c = c as char_t;
-    for i in range(0, n as int).rev() {
+    for i in range(0, n as isize).rev() {
         *offset_mut(dst, i) = c;
     }
     dst
@@ -303,8 +303,8 @@ pub unsafe extern fn strlen(s: *const char_t) -> size_t {
 
 #[no_mangle]
 pub unsafe extern fn strnlen(s: *const char_t, n: size_t) -> size_t {
-    let mut len: uint = 0;
-    while *offset(s, len as int) != 0 && len < (n as uint) {
+    let mut len: usize = 0;
+    while *offset(s, len as isize) != 0 && len < (n as usize) {
         len += 1;
     }
     len as size_t

--- a/src/libc/time.rs
+++ b/src/libc/time.rs
@@ -80,7 +80,7 @@ fn MONTHLEN(ly: bool, mon: int_t) -> u64 {
 		[31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
 		[31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31],
 	];
-	_ytab[ly as uint][mon as uint]
+	_ytab[ly as usize][mon as usize]
 }
 
 /// TODO negative times
@@ -148,7 +148,7 @@ pub unsafe extern fn localtime_r(timer: *const time_t) -> *const tm {
 #[no_mangle]
 pub unsafe extern fn timegm(timer_ptr: *const tm) -> time_t {
 	let timer: &tm = transmute(timer_ptr);
-	let yr = (timer.tm_year + EPOCH_YR);
+	let yr = timer.tm_year + EPOCH_YR;
 
 	let mut t = (yr as time_t -1970) * (YEARSIZE(yr) * SECS_DAY) as time_t;
 	t += timer.tm_yday as time_t * SECS_DAY as time_t;

--- a/src/libc/time.rs
+++ b/src/libc/time.rs
@@ -3,19 +3,6 @@ use consts::NULL;
 use types::{int_t, char_t, long_t, time_t, tm, timeval, timezone};
 use syscalls::sys_gettimeofday;
 
-use libc::errno::{errno};
-macro_rules! forward {
-    ($sys:ident, $($p:expr),*) => {
-        match $sys($($p),+) {
-            n if n < 0 => {
-                errno = -n;
-                -1
-            },
-            n => n,
-        }
-    };
-}
-
 #[no_mangle]
 pub unsafe extern fn time(time: *mut time_t) -> time_t {
 	let mut now: timeval = timeval {tv_sec: 0xabcd, tv_usec: 0xabcd};

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -1290,7 +1290,7 @@ pub fn gauss(x: f64) -> f64
 
 	match i {
 		11...150	=> M_1_SQRT2PI * exp(-0.5*y) / x * __poly(1./y, 7, tab3),
-		1 ... 10	=> -__poly((x - i as f64), 31, &tab2[i as uint-1]),
+		1 ... 10	=> -__poly((x - i as f64), 31, &tab2[i as usize-1]),
 		0	=> 0.5 - x * __poly(y, 9, tab1),
 		_	=> 0.,
 	}

--- a/src/posix/mm.rs
+++ b/src/posix/mm.rs
@@ -15,18 +15,6 @@ use rust::prelude::*;
 use consts::errno::{ENOMEM};
 use libc::errno::{errno};
 
-macro_rules! forward {
-    ($sys:ident, $($p:expr),*) => {
-        match $sys($($p),*) {
-            n if n < 0 => {
-                errno = -n;
-                -1
-            },
-            n => n,
-        }
-    };
-}
-
 /// Increases the data break to the given address, returning 0 on success
 /// or -1 on failure, setting errno to ENOMEM.
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -54,10 +42,10 @@ pub unsafe extern fn sbrk(increment: intptr_t) -> *const void_t {
             errno = ENOMEM;
             -1 as *const void_t
         } else {
-            oldbrk
+            oldbrk as *const void_t
         }
     } else {
-        oldbrk
+        oldbrk as *const void_t
     }
 }
 

--- a/src/posix/mm.rs
+++ b/src/posix/mm.rs
@@ -1,0 +1,99 @@
+//! Memory management
+
+use types::{int_t, uint_t, ulong_t, void_t, size_t, intptr_t};
+use types::{off_t};
+use types::{rlimit};
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+use types::{caddr_t};
+
+use syscalls::{sys_getrlimit, sys_mmap, sys_munmap};
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+use syscalls::{sys_brk};
+
+use rust::prelude::*;
+
+use consts::errno::{ENOMEM};
+use libc::errno::{errno};
+
+macro_rules! forward {
+    ($sys:ident, $($p:expr),*) => {
+        match $sys($($p),*) {
+            n if n < 0 => {
+                errno = -n;
+                -1
+            },
+            n => n,
+        }
+    };
+}
+
+/// Increases the data break to the given address, returning 0 on success
+/// or -1 on failure, setting errno to ENOMEM.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[no_mangle]
+pub unsafe extern fn brk(addr: *const void_t) -> int_t {
+    match sys_brk(addr as ulong_t) == 0 {
+        true => 0,
+        false => {
+            errno = ENOMEM;
+            -1
+        }
+    }
+}
+
+/// Increments the data break by `increment`, returning either the previous
+/// break or `((void*)-1)` on failure, setting errno to ENOMEM.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[no_mangle]
+pub unsafe extern fn sbrk(increment: intptr_t) -> *const void_t {
+    let oldbrk: *const void_t = sys_brk(0) as *const void_t;
+    if increment != 0 {
+        let newbrk: *const void_t = offset(oldbrk, increment as isize);
+        if sys_brk(newbrk as ulong_t) as *const void_t != newbrk {
+            errno = ENOMEM;
+            -1 as *const void_t
+        } else {
+            oldbrk
+        }
+    } else {
+        oldbrk
+    }
+}
+
+/// Get resource limits. For RLIMIT_DATA, this is the maximum size of the
+/// process's data segment. This limit affects calls to brk(2) and sbrk(2).
+#[no_mangle]
+pub unsafe extern fn getrlimit(resource: int_t, rlim: *mut rlimit) -> int_t {
+    (forward!(sys_getrlimit, resource as uint_t, rlim))
+}
+
+/// Map or unmap files or devices into memory.
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[no_mangle]
+pub unsafe extern fn mmap(
+        addr: *const void_t, length: size_t, prot: int_t, flags: int_t,
+        fd: int_t, offset: off_t) -> *const void_t {
+    forward!(sys_mmap, addr as ulong_t, length as ulong_t, prot as ulong_t,
+        flags as ulong_t, fd as ulong_t, offset as ulong_t) as *const void_t
+}
+
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+#[no_mangle]
+pub unsafe extern fn mmap(
+        addr: *const void_t, length: size_t, prot: int_t, flags: int_t,
+        fd: int_t, offset: off_t) -> *const void_t {
+    forward!(sys_mmap, addr as caddr_t, length, prot, flags, fd, offset)
+        as *const void_t
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#[no_mangle]
+pub unsafe extern fn munmap(addr: *const void_t, length: size_t) -> int_t {
+    forward!(sys_munmap, addr as ulong_t, length)
+}
+
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+#[no_mangle]
+pub unsafe extern fn munmap(addr: *const void_t, length: size_t) -> int_t {
+    forward!(sys_munmap, addr as caddr_t, length)
+}

--- a/src/posix/mm.rs
+++ b/src/posix/mm.rs
@@ -32,7 +32,8 @@ macro_rules! forward {
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[no_mangle]
 pub unsafe extern fn brk(addr: *const void_t) -> int_t {
-    match sys_brk(addr as ulong_t) == 0 {
+    let oldbrk = sys_brk(0) as usize;
+    match sys_brk(addr as ulong_t) as usize != oldbrk {
         true => 0,
         false => {
             errno = ENOMEM;
@@ -46,10 +47,10 @@ pub unsafe extern fn brk(addr: *const void_t) -> int_t {
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[no_mangle]
 pub unsafe extern fn sbrk(increment: intptr_t) -> *const void_t {
-    let oldbrk: *const void_t = sys_brk(0) as *const void_t;
+    let oldbrk = sys_brk(0) as *const u8;
     if increment != 0 {
-        let newbrk: *const void_t = offset(oldbrk, increment as isize);
-        if sys_brk(newbrk as ulong_t) as *const void_t != newbrk {
+        let newbrk = offset(oldbrk, increment as isize);
+        if sys_brk(newbrk as ulong_t) as *const u8 != newbrk {
             errno = ENOMEM;
             -1 as *const void_t
         } else {

--- a/src/posix/mod.rs
+++ b/src/posix/mod.rs
@@ -1,5 +1,7 @@
 pub mod unistd;
 pub mod stdlib;
+pub mod mm;
 pub mod fcntl;
 pub mod dlfcn;
 pub mod signal;
+pub mod utime;

--- a/src/posix/signal.rs
+++ b/src/posix/signal.rs
@@ -13,7 +13,7 @@ type __sa_handler_t = fn(int_t);
 type __sa_sigaction = fn(int_t, *mut void_t, *mut void_t);
 type __sigaction_u_t = *mut void_t;
 type sigset_t = u32;
-#[repr = "C"]
+#[repr(C)]
 struct sigaction_s {
 	__sigaction_u: __sigaction_u_t,
 	sa_mask: sigset_t,

--- a/src/posix/stdlib.rs
+++ b/src/posix/stdlib.rs
@@ -9,13 +9,13 @@ use posix::signal::{raise, SIGABRT};
 
 use syscalls::{sys_exit};
 
-pub static mut ARGV: *const *const char_t = 0u as *const *const char_t;
-pub static mut ARGC: uint = 0;
-pub static mut ENVP: *const *const char_t = 0u as *const *const char_t;
-pub static mut ENVC: uint = 0;
+pub static mut ARGV: *const *const char_t = 0us as *const *const char_t;
+pub static mut ARGC: usize = 0;
+pub static mut ENVP: *const *const char_t = 0us as *const *const char_t;
+pub static mut ENVC: usize = 0;
 
 #[cfg(target_os = "macos")]
-pub static mut APPLE: *const *const char_t = 0u as *const *const char_t;
+pub static mut APPLE: *const *const char_t = 0us as *const *const char_t;
 
 const K_ENV_MAXKEYLEN: size_t = 512;
 
@@ -38,7 +38,7 @@ pub unsafe extern fn get_envp() -> &'static [*const char_t] {
 #[no_mangle]
 #[cfg(target_os = "macos")]
 pub unsafe extern fn _NSGetArgc() -> *const int_t {
-    (&ARGC) as *const uint as *const int_t
+    (&ARGC) as *const usize as *const int_t
 }
 
 #[no_mangle]
@@ -76,8 +76,8 @@ pub unsafe extern fn _NSGetExecutablePath(buf: *mut char_t, size: *mut u32) -> i
 pub unsafe extern fn getenv(key: *const char_t) -> *const char_t {
     let len = strnlen(key, K_ENV_MAXKEYLEN);
     for &env in get_envp().iter() {
-        if strncmp(key, env, len) == 0 && *offset(env, len as int) == '=' as i8 {
-            return offset(env, (len as int) + 1)
+        if strncmp(key, env, len) == 0 && *offset(env, len as isize) == '=' as i8 {
+            return offset(env, (len as isize) + 1)
         }
     }
     0 as *const char_t
@@ -123,7 +123,7 @@ pub unsafe extern fn abort() {
 /*
 #[no_mangle]
 pub unsafe extern fn mkstemp(tplt: *mut char_t) -> int_t {
-    let slc = tplt.to_mut_slice(strlen(tplt as *_) as uint);
+    let slc = tplt.to_mut_slice(strlen(tplt as *_) as usize);
     if slc.len() < 6 || slc.lastn(6).iter().any(|c| *c != cc!('X')) {
         errno = EINVAL;
         return -1;

--- a/src/posix/utime.rs
+++ b/src/posix/utime.rs
@@ -4,19 +4,6 @@ use types::{char_t, int_t, timeval, utimbuf};
 use syscalls::sys_utimes;
 use rust::prelude::*;
 
-use libc::errno::{errno};
-macro_rules! forward {
-    ($sys:ident, $($p:expr),*) => {
-        match $sys($($p),*) {
-            n if n < 0 => {
-                errno = -n;
-                -1
-            },
-            n => n,
-        }
-    };
-}
-
 /// Change file last access and modification times.
 #[no_mangle]
 pub unsafe extern fn utime(path: *const char_t, times: *const utimbuf) -> int_t {

--- a/src/posix/utime.rs
+++ b/src/posix/utime.rs
@@ -20,20 +20,20 @@ macro_rules! forward {
 /// Change file last access and modification times.
 #[no_mangle]
 pub unsafe extern fn utime(path: *const char_t, times: *const utimbuf) -> int_t {
-	if times.is_null() {
-		let mut tv = [
-			timeval {
-				tv_sec: (*times).actime,
-				tv_usec: 0,
-			},
-			timeval {
-				tv_sec: (*times).modtime,
-				tv_usec: 0,
-			}
-		];
-		forward!(sys_utimes, path, tv.as_mut_ptr())
-	} else {
-		forward!(sys_utimes, path, 0 as *mut timeval)
-	}
+    if times.is_null() {
+        let mut tv = [
+            timeval {
+                tv_sec: (*times).actime,
+                tv_usec: 0,
+            },
+            timeval {
+                tv_sec: (*times).modtime,
+                tv_usec: 0,
+            }
+        ];
+        forward!(sys_utimes, path, tv.as_mut_ptr())
+    } else {
+        forward!(sys_utimes, path, 0 as *mut timeval)
+    }
 }
 

--- a/src/posix/utime.rs
+++ b/src/posix/utime.rs
@@ -1,0 +1,39 @@
+//! File access and modification
+
+use types::{char_t, int_t, timeval, utimbuf};
+use syscalls::sys_utimes;
+use rust::prelude::*;
+
+use libc::errno::{errno};
+macro_rules! forward {
+    ($sys:ident, $($p:expr),*) => {
+        match $sys($($p),*) {
+            n if n < 0 => {
+                errno = -n;
+                -1
+            },
+            n => n,
+        }
+    };
+}
+
+/// Change file last access and modification times.
+#[no_mangle]
+pub unsafe extern fn utime(path: *const char_t, times: *const utimbuf) -> int_t {
+	if times.is_null() {
+		let mut tv = [
+			timeval {
+				tv_sec: (*times).actime,
+				tv_usec: 0,
+			},
+			timeval {
+				tv_sec: (*times).modtime,
+				tv_usec: 0,
+			}
+		];
+		forward!(sys_utimes, path, tv.as_mut_ptr())
+	} else {
+		forward!(sys_utimes, path, 0 as *mut timeval)
+	}
+}
+

--- a/src/rust/macros.rs
+++ b/src/rust/macros.rs
@@ -11,3 +11,16 @@ macro_rules! cs {
         (concat!($e, "\0")).repr().data as *const char_t
     }
 }
+
+macro_rules! forward {
+    ($sys:ident, $($p:expr),*) => {
+        match $sys($($p),*) {
+            n if n < 0 => {
+                use libc::errno::{errno};
+                errno = -n;
+                -1
+            },
+            n => n,
+        }
+    };
+}

--- a/src/rust/macros.rs
+++ b/src/rust/macros.rs
@@ -1,5 +1,3 @@
-#![macro_escape]
-
 #[macro_export]
 macro_rules! cc {
     ($e:expr) => {

--- a/src/rust/mod.rs
+++ b/src/rust/mod.rs
@@ -1,5 +1,6 @@
-#![macro_escape]
+//! The Rust core prelude.
 
+#[macro_use]
 pub mod macros;
 
 #[cfg(target_arch = "x86_64")]
@@ -14,13 +15,14 @@ pub mod prelude {
     pub use core::raw::{Repr};
     pub use core::intrinsics::{offset, uninit, copy_nonoverlapping_memory};
     pub use core::ops::*;
+    pub use core::ptr::{PtrExt};
     pub use core::clone::{Clone};
     pub use core::num::{Int, Float};
     pub use core::mem::transmute;
     pub use super::rand::{Rand, os_rand};
 
     #[inline(always)]
-    pub unsafe fn offset_mut<T>(dst: *mut T, n: int) -> *mut T {
+    pub unsafe fn offset_mut<T>(dst: *mut T, n: isize) -> *mut T {
         offset(dst as *const T, n) as *mut T
     }
 

--- a/src/rust/x86_64/linux/start.rs
+++ b/src/rust/x86_64/linux/start.rs
@@ -12,16 +12,16 @@ extern "C" {
 /// It stores the addresses of the stack arguments, invokes main(), and passes
 /// the return status to exit().
 #[no_mangle]
-pub unsafe extern fn __libc_start_main(argc: uint, argv: *const *const char_t) {
+pub unsafe extern fn __libc_start_main(argc: usize, argv: *const *const char_t) {
     ARGC = argc;
     ARGV = argv;
-    ENVP = offset(ARGV, ARGC as int + 1);
+    ENVP = offset(ARGV, ARGC as isize + 1);
 
     let mut envc: *const *const char_t = ENVP;
-    while (*envc as uint != 0) {
+    while *envc as usize != 0 {
         envc = offset(envc, 1); // increases by one pointer size
     }
-    ENVC = (envc as uint - ENVP as uint - 1);
+    ENVC = envc as usize - ENVP as usize - 1;
 
-    call_main(ARGC as int_t, ARGV, ENVP);
+    exit(main(ARGC as int_t, ARGV, ENVP));
 }

--- a/src/rust/x86_64/macos/start.rs
+++ b/src/rust/x86_64/macos/start.rs
@@ -13,16 +13,16 @@ extern "C" {
 /// Also, Rust inserts the frame-pointer prelude, which is invalid
 /// for an executable's entry point.
 #[no_mangle]
-pub unsafe extern fn _libc_start_main(argc: uint, argv: *const *const char_t) {
+pub unsafe extern fn _libc_start_main(argc: usize, argv: *const *const char_t) {
     ARGC = argc;
     ARGV = argv;
-    ENVP = offset(ARGV, ARGC as int + 1);
+    ENVP = offset(ARGV, ARGC as isize + 1);
 
     let mut apple: *const *const char_t = ENVP;
-    while (*apple as uint != 0) {
+    while *apple as usize != 0 {
         apple = offset(apple, 1); // increases by one pointer size
     }
-    ENVC = (apple as uint - ENVP as uint - 1);
+    ENVC = apple as usize - ENVP as usize - 1;
     apple = offset(apple, 1); // one NULL pointer separates apple[] from env[]
     APPLE = apple;
 

--- a/src/syscalls/linux/x86_64.rs
+++ b/src/syscalls/linux/x86_64.rs
@@ -329,7 +329,7 @@ syscall!(231, sys_exit_group, int_t);
 syscall!(232, sys_epoll_wait, int_t, *mut epoll_event, int_t, int_t);
 syscall!(233, sys_epoll_ctl, int_t, int_t, int_t, *mut epoll_event);
 syscall!(234, sys_tgkill, pid_t, pid_t, int_t);
-syscall!(235, sys_utimes, *mut char_t, *mut timeval);
+syscall!(235, sys_utimes, *const char_t, *mut timeval); // WARNING *mut char_t
 // syscall!(236, sys_vserver, NOT);
 syscall!(237, sys_mbind, ulong_t, ulong_t, ulong_t, *mut ulong_t, ulong_t, uint_t);
 syscall!(238, sys_set_mempolicy, int_t, *mut ulong_t, ulong_t);

--- a/src/syscalls/linux/x86_64.rs
+++ b/src/syscalls/linux/x86_64.rs
@@ -1,3 +1,5 @@
+#![allow(unused_assignments)]
+
 use types::*;
 
 macro_rules! syscall {

--- a/src/syscalls/macos/x86_64.rs
+++ b/src/syscalls/macos/x86_64.rs
@@ -1,3 +1,5 @@
+#![allow(unused_assignments)]
+
 use types::*;
 
 /*
@@ -24,7 +26,7 @@ use types::*;
  * call = class << 24 & class_mask | id & !class_mask
  */
 
-const CLASS_SHIFT: uint = 24;
+const CLASS_SHIFT: usize = 24;
 const CLASS_MASK: int_t = 0xFF << CLASS_SHIFT;
 const NUMBER_MASK: int_t = !CLASS_MASK;
 
@@ -142,11 +144,14 @@ syscall!(2, 025, sys_geteuid);
 
 syscall!(2, 037, sys_kill, int_t, int_t, int_t);
 
+syscall!(2, 073, sys_munmap, caddr_t, size_t);
+
 syscall!(2, 116, sys_gettimeofday, *mut timeval, *mut timezone);
 
 syscall!(2, 128, sys_rename, *const char_t, *const char_t);
 
 syscall!(2, 137, sys_rmdir, *const char_t);
+syscall!(2, 138, sys_utimes, *const char_t, *mut timeval); // WARNING *mut char_t
 
 syscall!(2, 147, sys_setsid);
 
@@ -154,5 +159,10 @@ syscall!(2, 153, sys_pread, int_t, *mut char_t, size_t, off_t);
 syscall!(2, 154, sys_pwrite, int_t, *const char_t, size_t, off_t);
 
 syscall!(2, 181, sys_setgid, gid_t);
+
+syscall!(2, 193, sys_getrlimit, uint_t, *mut rlimit);
+syscall!(2, 194, sys_setrlimit, uint_t, *mut rlimit);
+
+syscall!(2, 197, sys_mmap, caddr_t, size_t, int_t, int_t, int_t, off_t);
 
 syscall!(2, 199, sys_lseek, int_t, off_t, int_t);

--- a/src/types/linux/mod.rs
+++ b/src/types/linux/mod.rs
@@ -112,13 +112,13 @@ pub struct timespec {
     pub tv_nsec: long_t,
 }
 
-pub const NSIG: uint = 64;
+pub const NSIG: usize = 64;
 #[no_mangle]
-pub static _NSIG: uint = NSIG;
+pub static _NSIG: usize = NSIG;
 
-pub const NSIG_WORDS: uint = NSIG / NSIG_BPW;
+pub const NSIG_WORDS: usize = NSIG / NSIG_BPW;
 #[no_mangle]
-pub static _NSIG_WORDS: uint = NSIG_WORDS;
+pub static _NSIG_WORDS: usize = NSIG_WORDS;
 
 pub struct sigset_t {
     pub sig: [ulong_t; NSIG_WORDS],

--- a/src/types/linux/x86_64.rs
+++ b/src/types/linux/x86_64.rs
@@ -54,9 +54,9 @@ pub type __kernel_size_t    = ulong_t;
 pub type __kernel_ssize_t   = long_t;
 pub type __kernel_ptrdiff_t = long_t;
 
-pub const NSIG_BPW: uint = 64;
+pub const NSIG_BPW: usize = 64;
 #[no_mangle]
-pub static _NSIG_BPW: uint = NSIG_BPW;
+pub static _NSIG_BPW: usize = NSIG_BPW;
 
 #[packed]
 pub struct epoll_event {
@@ -156,10 +156,10 @@ pub struct msg {
 
 pub type __statfs_word = long_t;
 
-pub const FD_SETSIZE: uint = 1024;
+pub const FD_SETSIZE: usize = 1024;
 
 #[no_mangle]
-pub static __FD_SETSIZE: uint = FD_SETSIZE;
+pub static __FD_SETSIZE: usize = FD_SETSIZE;
 pub struct __kernel_fd_set {
     // XXX size_of
     pub fds_bits: [ulong_t; (FD_SETSIZE / (8 * 8))],

--- a/src/types/macos/x86_64.rs
+++ b/src/types/macos/x86_64.rs
@@ -100,11 +100,22 @@ pub struct timezone {
     pub tz_dsttime: int_t,
 }
 #[repr(C)]
+pub struct utimbuf {
+    pub actime: time_t,
+    pub modtime: time_t,
+}
+#[repr(C)]
 pub struct fd_set {
-    pub fds_bits: [int32_t; 32u],
+    pub fds_bits: [int32_t; 32us],
+}
+#[repr(C)]
+pub struct rlimit {
+    pub rlim_cur: ulong_t,
+    pub rlim_max: ulong_t,
 }
 
 // kernel
 pub type user_addr_t = u64;
 pub type user_size_t = u64;
 pub type user_ssize_t = i64;
+pub type caddr_t = *const char_t;


### PR DESCRIPTION
This commit updates the the int/uint and macro escaping syntax for 1.0, and also adds mmap() and utime().